### PR TITLE
Trivially improve Swift efficiency by not calling random as many times

### DIFF
--- a/src/uuidv7.swift
+++ b/src/uuidv7.swift
@@ -4,12 +4,12 @@ extension UUID {
     static func v7() -> Self {
         // random bytes
         var value = (
-            UInt8.random(in: 0...255),
-            UInt8.random(in: 0...255),
-            UInt8.random(in: 0...255),
-            UInt8.random(in: 0...255),
-            UInt8.random(in: 0...255),
-            UInt8.random(in: 0...255),
+            UInt8(0),
+            UInt8(0),
+            UInt8(0),
+            UInt8(0),
+            UInt8(0),
+            UInt8(0),
             UInt8.random(in: 0...255),
             UInt8.random(in: 0...255),
             UInt8.random(in: 0...255),


### PR DESCRIPTION
Hey.

Tiny trivial efficiency improvement to the swift version, reducing the number of calls to `random()`.

If the uuid spec sets the first 6 bytes to a known value (explicitly setting value.0 ... value.5 on lines 29-34), we don't need to initialise them with a random value, we can just use 0.

The other two values set (value.6 and value.8) are only setting half the byte, so I've left the random calls in for them.
