### PR TITLE
POSIX shell changes

### DIFF
--- a/src/uuidv7.sh
+++ b/src/uuidv7.sh
@@ -7,18 +7,18 @@ uuidv7() {
     timestamp_lo=$(( timestamp & 0xFF ))
 
     # 16 random bits (12 will be used)
-    rand_a=0x$(head -c 2 /dev/urandom|xxd -ps)
+    rand_a=0x$(LC_ALL=C tr -dc '0-9a-f' < /dev/urandom|head -c4)
     # ver is 0x7
-    ver_rand_a=$(( 0x7000 | ( 0xFFF & rand_a ) ))
+    ver_rand_a=$(( 0x7000 | ( 0xFFF & rand_a ) )) 
 
     # 16 random bits (14 will be used)
-    rand_b_1=0x$(head -c 2 /dev/urandom|xxd -ps)
+    rand_b_hi=0x$(LC_ALL=C tr -dc '0-9a-f' < /dev/urandom|head -c4)
     # var is 0b10
-    var_rand_b=$(( 0x8000 | ( 0x3FFF & rand_b_1 ) ))
+    var_rand_hi=$(( 0x8000 | ( 0x3FFF & rand_b_hi ) ))
     # remaining 48 bits of rand b
-    rand_b_2=$(head -c 6 /dev/urandom|xxd -ps)
+    rand_b_lo=$(LC_ALL=C tr -dc '0-9a-f' < /dev/urandom|head -c12)
 
-    printf "%08x-%04x-%04x-%4x-%s" "$timestamp_hi" "$timestamp_lo" "$ver_rand_a" "$var_rand_b" "$rand_b_2"
+    printf "%08x-%04x-%04x-%4x-%s" "$timestamp_hi" "$timestamp_lo" "$ver_rand_a" "$var_rand_hi" "$rand_b_lo"
 }
 
 for byte in $(uuidv7); do

--- a/src/uuidv7.sh
+++ b/src/uuidv7.sh
@@ -4,7 +4,7 @@ uuidv7() {
     # current timestamp in ms. POSIX date does not support %3N.
     timestamp=$(date +%s)000
     timestamp_hi=$(( timestamp >> 16 ))
-    timestamp_lo=$(( timestamp & 0xFF ))
+    timestamp_lo=$(( timestamp & 0xFFFF ))
 
     # 16 random bits (12 will be used)
     rand_a=0x$(LC_ALL=C tr -dc '0-9a-f' < /dev/urandom|head -c4)

--- a/src/uuidv7.sh
+++ b/src/uuidv7.sh
@@ -1,38 +1,24 @@
 #!/bin/sh
 
 uuidv7() {
-    # random bytes
-    rand_bytes=$(dd if=/dev/urandom bs=1 count=16 2>/dev/null | xxd -p)
+    # current timestamp in ms. POSIX date does not support %3N.
+    timestamp=$(date +%s)000
+    timestamp_hi=$(( timestamp >> 16 ))
+    timestamp_lo=$(( timestamp & 0xFF ))
 
-    # current timestamp in ms
-    timestamp=$(date +%s%3N)
-    t_hex=$(printf "%012x" $timestamp)
+    # 16 random bits (12 will be used)
+    rand_a=0x$(head -c 2 /dev/urandom|xxd -ps)
+    # ver is 0x7
+    ver_rand_a=$(( 0x7000 | ( 0xFFF & rand_a ) ))
 
-    # timestamp
-    value[0]=${t_hex:0:2}
-    value[1]=${t_hex:2:2}
-    value[2]=${t_hex:4:2}
-    value[3]=${t_hex:6:2}
-    value[4]=${t_hex:8:2}
-    value[5]=${t_hex:10:2}
+    # 16 random bits (14 will be used)
+    rand_b_1=0x$(head -c 2 /dev/urandom|xxd -ps)
+    # var is 0b10
+    var_rand_b=$(( 0x8000 | ( 0x3FFF & rand_b_1 ) ))
+    # remaining 48 bits of rand b
+    rand_b_2=$(head -c 6 /dev/urandom|xxd -ps)
 
-    # version / rand_a
-    value[6]=$(printf "%02x" $((0x70 | (0x${rand_bytes:12:2} & 0x0F))))
-    value[7]=${rand_bytes:14:2}
-
-    # variant / rand_b
-    value[8]=$(printf "%02x" $((0x80 | (0x${rand_bytes:16:2} & 0x3F))))
-
-    # rand_b
-    value[9]=${rand_bytes:18:2}
-    value[10]=${rand_bytes:20:2}
-    value[11]=${rand_bytes:22:2}
-    value[12]=${rand_bytes:24:2}
-    value[13]=${rand_bytes:26:2}
-    value[14]=${rand_bytes:28:2}
-    value[15]=${rand_bytes:30:2}
-
-    echo "${value[@]}"
+    printf "%08x-%04x-%04x-%4x-%s" "$timestamp_hi" "$timestamp_lo" "$ver_rand_a" "$var_rand_b" "$rand_b_2"
 }
 
 for byte in $(uuidv7); do


### PR DESCRIPTION
POSIX date does not support the %N format, also POSIX shell does not support the substring expansion format, or arrays.

Another problem with the original script is the use of dd, which may not return the number of bytes expected (see https://unix.stackexchange.com/questions/121865/create-random-data-with-dd-and-get-partial-read-warning-is-the-data-after-the#121888)

The original also did not format the resulting string like the other scripts in 8-4-4-4-6 format.

I think it's fine to change the original script to specify bash as the shell not sh, but just to point out the issues, here's a stab at a posixly correct version? (shellcheck at least does not complain)