### PR TITLE
Julia impl: opt UInt64 convert to Vector{UInt8}: replace reinterpret with digits!

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ See [RFC 9652](https://www.rfc-editor.org/rfc/rfc9562#name-uuid-version-7) for d
 [Go](src/uuidv7.go) •
 [Java](src/uuidv7.java) •
 [JavaScript](src/uuidv7.js) •
+[Julia](src/uuidv7.jl) •
 [Kotlin](src/uuidv7.kt) •
 [Lua](src/uuidv7.lua) •
 [Nim](src/uuidv7.nim) •

--- a/src/uuidv7.jl
+++ b/src/uuidv7.jl
@@ -3,7 +3,7 @@ function uuidv7()
   value = rand(UInt8, 16)
 
   # current timestamp
-  timestamp = trunc(UInt64,time() * 1000)
+  timestamp = trunc(UInt64, time() * 1000)
 
   # timestamp
   value[1:6] = [

--- a/src/uuidv7.jl
+++ b/src/uuidv7.jl
@@ -4,7 +4,7 @@ function uuidv7()
 
   # current timestamp
   timestamp = trunc(UInt64, time() * 1000)
-  reinterpret(UInt8, [timestamp]) |> reverse! |> x -> copyto!(value, 1, x, 3, 6)
+  reinterpret(UInt8, [timestamp])[1:end-2] |> reverse! |> x -> copyto!(value, 1, x, 1, 6)
 
   # version and variant
   value[7] = value[7] & 0x0F | 0x70

--- a/src/uuidv7.jl
+++ b/src/uuidv7.jl
@@ -4,16 +4,7 @@ function uuidv7()
 
   # current timestamp
   timestamp = trunc(UInt64, time() * 1000)
-
-  # timestamp
-  value[1:6] = [
-    timestamp >> 40 & 0xFF,
-    timestamp >> 32 & 0xFF,
-    timestamp >> 24 & 0xFF,
-    timestamp >> 16 & 0xFF,
-    timestamp >> 8 & 0xFF,
-    timestamp & 0xFF
-  ]
+  reinterpret(UInt8, [timestamp]) |> reverse! |> x -> copyto!(value, 1, x, 3, 6)
 
   # version and variant
   value[7] = value[7] & 0x0F | 0x70

--- a/src/uuidv7.jl
+++ b/src/uuidv7.jl
@@ -1,0 +1,25 @@
+function uuidv7()
+  # random bytes
+  value = rand(UInt8, 16)
+
+  # current timestamp
+  timestamp = trunc(UInt64,time() * 1000)
+
+  # timestamp
+  value[1:6] = [
+    timestamp >> 40 & 0xFF,
+    timestamp >> 32 & 0xFF,
+    timestamp >> 24 & 0xFF,
+    timestamp >> 16 & 0xFF,
+    timestamp >> 8 & 0xFF,
+    timestamp & 0xFF
+  ]
+
+  # version and variant
+  value[7] = value[7] & 0x0F | 0x70
+  value[9] = value[9] & 0x3F | 0x80
+
+  value
+end
+
+uuidv7() |> bytes2hex |> println

--- a/src/uuidv7.jl
+++ b/src/uuidv7.jl
@@ -4,7 +4,7 @@ function uuidv7()
 
   # current timestamp
   timestamp = trunc(UInt64, time() * 1000)
-  reinterpret(UInt8, [timestamp])[1:end-2] |> reverse! |> x -> copyto!(value, 1, x, 1, 6)
+  digits!(UInt8[0, 0, 0, 0, 0, 0], timestamp, base=256) |> reverse! |> x -> copyto!(value, 1, x, 1, 6)
 
   # version and variant
   value[7] = value[7] & 0x0F | 0x70


### PR DESCRIPTION
bench result:

|item|avg|
|:---:|:----:|
use reinterpret | 98.017 ns (3 allocations: 208 bytes)
use digits! | 78.189 ns (2 allocations: 144 bytes)

online playground: https://www.jdoodle.com/ia/14aN