### PR TITLE
Update uuidv7.r

### DIFF
--- a/src/uuidv7.r
+++ b/src/uuidv7.r
@@ -1,24 +1,18 @@
 uuidv7 <- function() {
-  # random bytes
-  value <- as.raw(sample(0:255, 16, replace = TRUE))
-
-  # current timestamp in ms
-  timestamp <- as.numeric(Sys.time()) * 1000
-
+  # Initialise vector with current timestamp & random numbers
+  value = numeric(16)
+  value[1:6] <- as.numeric(Sys.time()) * 1000
+  value[7:16] <- sample(0:255, 10L, replace = TRUE)
+ 
   # timestamp
-  value[1] <- as.raw((timestamp %/% 2^40) %% 256)
-  value[2] <- as.raw((timestamp %/% 2^32) %% 256)
-  value[3] <- as.raw((timestamp %/% 2^24) %% 256)
-  value[4] <- as.raw((timestamp %/% 2^16) %% 256)
-  value[5] <- as.raw((timestamp %/% 2^8) %% 256)
-  value[6] <- as.raw(timestamp %% 256)
+  value[1:6] <- value[1:6] %/% 2^c(40, 32, 24, 16, 8, 1) %% 256L
 
   # version and variant
-  value[7] <- as.raw(bitwOr(bitwAnd(as.integer(value[7]), 0x0F), 0x70))
-  value[9] <- as.raw(bitwOr(bitwAnd(as.integer(value[9]), 0x3F), 0x80))
-
-  return(value)
+  value[7] <- bitwOr(bitwAnd(value[7], 0x0F), 0x70)
+  value[9] <- bitwOr(bitwAnd(value[9], 0x3F), 0x80)
+  as.raw(value)
 }
+
 
 uuid_val <- uuidv7()
 cat(paste(sprintf('%02x', as.integer(uuid_val)), collapse = ''))


### PR DESCRIPTION
More idiomatic R

R is vectorised, so instead of 

```
as.raw(value[1))
as.raw(value[2))
as.raw(value[3))
...

It should be `as.raw(value)`. Likewise with `%%` 