### PR TITLE
Fix tsql implementation generating only 32 bits of randomness / four leading zeros in rand_b

### DIFF
--- a/src/uuidv7.tsql
+++ b/src/uuidv7.tsql
@@ -25,7 +25,7 @@ begin
 
     -- Generate a large random value for the rand_b part and convert to hexadecimal
     declare @rand_b_bigint bigint = floor(rand(checksum(newid())) * power(cast(2 as bigint), 48))
-    set @rand_b = right('000000000000' + convert(varchar(12), convert(varbinary(6), @rand_b_bigint / 65536), 2), 12)
+    set @rand_b = right('000000000000' + convert(varchar(12), convert(varbinary(6), @rand_b_bigint), 2), 12)
 
     -- Combine all parts to form the final UUID v7-like value
     declare @UUIDv7 char(36)


### PR DESCRIPTION
The current tsql implementation generated an incorrect pattern `xxxxxxxx-xxxx-xxxx-0000xxxxxxxx`. This was due to a binary right shift of 16 bits caused by an incorrect division of the random 48 bit Integer by 2^16 (65536).