### PR TITLE
Simplify JavaScript with better performance

### DIFF
--- a/src/uuidv7.js
+++ b/src/uuidv7.js
@@ -1,23 +1,20 @@
 function uuidv7() {
-    // random bytes
-    const value = new Uint8Array(16);
-    crypto.getRandomValues(value);
-
+    const buffer = new ArrayBuffer(16);
+    const view = new DataView(buffer);
+    const value = new Uint8Array(buffer);
+    
     // current timestamp in ms
-    const timestamp = BigInt(Date.now());
-
-    // timestamp
-    value[0] = Number((timestamp >> 40n) & 0xffn);
-    value[1] = Number((timestamp >> 32n) & 0xffn);
-    value[2] = Number((timestamp >> 24n) & 0xffn);
-    value[3] = Number((timestamp >> 16n) & 0xffn);
-    value[4] = Number((timestamp >> 8n) & 0xffn);
-    value[5] = Number(timestamp & 0xffn);
-
+    const timestamp = Date.now();
+    view.setUint16(0, Math.floor(timestamp / 2**32));
+    view.setUint32(2, timestamp);
+    
+    // random bytes
+    crypto.getRandomValues(value.subarray(6));
+    
     // version and variant
     value[6] = (value[6] & 0x0f) | 0x70;
     value[8] = (value[8] & 0x3f) | 0x80;
-
+    
     return value;
 }
 

--- a/src/uuidv7.js
+++ b/src/uuidv7.js
@@ -2,19 +2,19 @@ function uuidv7() {
     const buffer = new ArrayBuffer(16);
     const view = new DataView(buffer);
     const value = new Uint8Array(buffer);
-    
+
     // current timestamp in ms
     const timestamp = Date.now();
     view.setUint16(0, Math.floor(timestamp / 2**32));
     view.setUint32(2, timestamp);
-    
+
     // random bytes
     crypto.getRandomValues(value.subarray(6));
-    
+
     // version and variant
     value[6] = (value[6] & 0x0f) | 0x70;
     value[8] = (value[8] & 0x3f) | 0x80;
-    
+
     return value;
 }
 


### PR DESCRIPTION
Hi, this is an alternative JavaScript implementation that uses `DataView`, which removes the need for BigInt conversion and those bite shifts. Also, this only generates 10 random bytes instead of full 16 with the 6 being later overwritten. I think it's logically clearer as well.

The second option is that if one doesn't necessarily need it as a `Uint8Array`, working directly with strings is easier: https://gist.github.com/robinpokorny/544c18e27d39573121c94c9419f7c498